### PR TITLE
URL level security using WebSecurityConfigurerAdapter

### DIFF
--- a/juneau-petstore-server/pom.xml
+++ b/juneau-petstore-server/pom.xml
@@ -91,12 +91,32 @@
             <groupId>org.springframework.boot</groupId>
 		    <artifactId>spring-boot-starter-data-jpa</artifactId>	 
         </dependency>
-        
+
+        <!-- Spring Security -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-security</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-config</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-core</artifactId>
+            <version>5.1.5.RELEASE</version>
+        </dependency>
+
       <!-- Cache -->
         <dependency>
            <groupId>org.springframework.boot</groupId>
            <artifactId>spring-boot-starter-cache</artifactId>
-        </dependency> 
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-test-autoconfigure</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/juneau-petstore-server/src/main/java/org/apache/juneau/petstore/config/SpringSecurityConfig.java
+++ b/juneau-petstore-server/src/main/java/org/apache/juneau/petstore/config/SpringSecurityConfig.java
@@ -23,10 +23,12 @@ public class SpringSecurityConfig extends WebSecurityConfigurerAdapter{
     protected void configure(HttpSecurity http) throws Exception {
 
         http
+                .httpBasic()
+                .and()
                 .authorizeRequests()
-                .antMatchers(HttpMethod.POST, "/pet").hasRole("ADMIN")
-                .antMatchers(HttpMethod.PUT, "/pet/**").hasRole("ADMIN")
-                .antMatchers(HttpMethod.DELETE, "/pet/**").hasRole("ADMIN")
+                .antMatchers(HttpMethod.POST, "/petstore/pet").hasRole("ADMIN")
+                .antMatchers(HttpMethod.PUT, "/petstore/pet/**").hasRole("ADMIN")
+                .antMatchers(HttpMethod.DELETE, "/petstore/pet/**").hasRole("ADMIN")
                 .and()
                 .csrf().disable()
                 .formLogin().disable();

--- a/juneau-petstore-server/src/main/java/org/apache/juneau/petstore/config/SpringSecurityConfig.java
+++ b/juneau-petstore-server/src/main/java/org/apache/juneau/petstore/config/SpringSecurityConfig.java
@@ -1,0 +1,35 @@
+package org.apache.juneau.petstore.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
+import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+
+@Configuration
+public class SpringSecurityConfig extends WebSecurityConfigurerAdapter{
+
+    @Override
+    protected void configure(AuthenticationManagerBuilder auth) throws Exception {
+
+        auth.inMemoryAuthentication()
+                .withUser("user").password("{noop}password").roles("USER")
+                .and()
+                .withUser("admin").password("{noop}password").roles("USER", "ADMIN");
+
+    }
+
+    @Override
+    protected void configure(HttpSecurity http) throws Exception {
+
+        http
+                .authorizeRequests()
+                .antMatchers(HttpMethod.POST, "/pet").hasRole("ADMIN")
+                .antMatchers(HttpMethod.PUT, "/pet/**").hasRole("ADMIN")
+                .antMatchers(HttpMethod.DELETE, "/pet/**").hasRole("ADMIN")
+                .and()
+                .csrf().disable()
+                .formLogin().disable();
+    }
+
+}


### PR DESCRIPTION
You need to add basic authentication to make a POST request. This lets users with role ADMIN to perform the POST request otherwise give 'HTTP 405: Method Not Allowed'.